### PR TITLE
incorrect call to menu._setDrag when no handle is created

### DIFF
--- a/src/wPaint.js
+++ b/src/wPaint.js
@@ -1002,7 +1002,11 @@
         // the items name here will be the menu name
         var menu = _this.wPaint.menus.all[item.name];
         menu.$menu.toggle();
-        menu._setDrag();
+        if (_this.handle) {
+          menu._setDrag();
+        } else {
+          menu._setPosition();
+        }
       }
 
       $icon.on('click', iconClick);


### PR DESCRIPTION
Exceptions were being thrown when options when the options specify {menuHandler: false}, and clicking on icon that opens a sub menu.

There problem was trying to call menu._setDrag, when the menu wasn't created as draggable.
