### PR TITLE
Correction of multiple instance of wPaint

### DIFF
--- a/src/wPaint.js
+++ b/src/wPaint.js
@@ -576,7 +576,7 @@
           menu.items[key].name = key;
 
           // use default img if img not set
-          menu.items[key].img = _this.wPaint.options.path + (menu.items[key].img || menu.img);
+          menu.items[key].img = _this.wPaint.options.path + menu.img;
 
           // make self invoking to avoid overwrites
           (itemAppend)(menu.items[key]);


### PR DESCRIPTION
Hi,

this correction is needed to avoid to have an error in the path of menu's images after some instances of wPaint.

Indeed :
Initially, the items of $.fn.wPaint.menus have their img attribute set to "plugins/main/img/...". After the first initialization with "element.wPaint()", $.fn.wPaint.menus have their img attribute set to "<path>plugins/main/img/..."
If we have another page with wPaint, the path is set to "<path><path>plugins/main/img/..." (path is appended for each loading).

Thx.
