### PR TITLE
Correct path plugins issue when reload wPaint

### DIFF
--- a/src/wPaint.js
+++ b/src/wPaint.js
@@ -562,11 +562,16 @@
         // only add unique (new) items (icons)
         if (!this.$menuHolder.children('.wPaint-menu-icon-name-' + key).length) {
           
-          // add the item name, we will need this internally
-          menu.items[key].name = key;
+        // add the item name, we will need this internally
+        menu.items[key].name = key;
 
-          // use default img if img not set
-          menu.items[key].img = _this.wPaint.options.path + (menu.items[key].img || menu.img);
+        // use default img if img not set
+        if(!menu.items[key].img) {
+            menu.items[key].img = _this.wPaint.options.path + menu.img;
+        } else if(menu.items[key].img.indexOf(_this.wPaint.options.path) !== 0) {
+            // if plugin path does not start by options.path add it
+            menu.items[key].img = _this.wPaint.options.path + menu.items[key].img;
+        }
 
           // make self invoking to avoid overwrites
           (itemAppend)(menu.items[key]);


### PR DESCRIPTION
When refresh wPaint, the options.path is added each time.

So this modification will:
- add default image if no image provided
- add option path only if plugin path not already start by it.

Regards,
Frederic.
